### PR TITLE
Fix typo in UnsafeSCWindow

### DIFF
--- a/screencapturekit-sys/src/shareable_content.rs
+++ b/screencapturekit-sys/src/shareable_content.rs
@@ -59,7 +59,7 @@ impl UnsafeSCWindow {
         unsafe { msg_send![self, windowID] }
     }
     pub fn get_frame(&self) -> CGRect {
-        unsafe { msg_send![self, windowID] }
+        unsafe { msg_send![self, frame] }
     }
     pub fn get_title(&self) -> Option<String> {
         unsafe { get_string!(self, title) }

--- a/screencapturekit/src/sc_running_application.rs
+++ b/screencapturekit/src/sc_running_application.rs
@@ -1,9 +1,8 @@
-use screencapturekit_sys::{shareable_content::UnsafeSCRunningApplication, os_types::rc::ShareId};
+use screencapturekit_sys::{os_types::rc::ShareId, shareable_content::UnsafeSCRunningApplication};
 
-
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SCRunningApplication {
-    pub (crate) _unsafe_ref: ShareId<UnsafeSCRunningApplication>,
+    pub(crate) _unsafe_ref: ShareId<UnsafeSCRunningApplication>,
     pub process_id: i32,
     pub bundle_identifier: Option<String>,
     pub application_name: Option<String>,
@@ -19,4 +18,3 @@ impl From<ShareId<UnsafeSCRunningApplication>> for SCRunningApplication {
         }
     }
 }
-

--- a/screencapturekit/src/sc_window.rs
+++ b/screencapturekit/src/sc_window.rs
@@ -1,12 +1,14 @@
-use screencapturekit_sys::{os_types::rc::ShareId, shareable_content::UnsafeSCWindow};
+use screencapturekit_sys::{
+    os_types::{geometry::CGRect, rc::ShareId},
+    shareable_content::UnsafeSCWindow,
+};
 
 use crate::sc_running_application::SCRunningApplication;
 
 #[derive(Debug)]
 pub struct SCWindow {
     pub(crate) _unsafe_ref: ShareId<UnsafeSCWindow>,
-    pub width: u32,
-    pub height: u32,
+    pub rect: CGRect,
     pub title: Option<String>,
     pub owning_application: Option<SCRunningApplication>,
     pub window_id: u32,
@@ -20,8 +22,7 @@ impl From<ShareId<UnsafeSCWindow>> for SCWindow {
         let frame = unsafe_ref.get_frame();
         SCWindow {
             title: unsafe_ref.get_title(),
-            width: frame.size.width as u32,
-            height: frame.size.height as u32,
+            rect: frame,
             window_id: unsafe_ref.get_window_id(),
             window_layer: unsafe_ref.get_window_layer(),
             is_active: unsafe_ref.get_is_active() == 1,

--- a/screencapturekit/src/sc_window.rs
+++ b/screencapturekit/src/sc_window.rs
@@ -5,7 +5,7 @@ use screencapturekit_sys::{
 
 use crate::sc_running_application::SCRunningApplication;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SCWindow {
     pub(crate) _unsafe_ref: ShareId<UnsafeSCWindow>,
     pub rect: CGRect,


### PR DESCRIPTION
A typo in the get_frame makes the CGRect get the wrong value.
