### PR TITLE
Don't panic on new_completion_handler

### DIFF
--- a/screencapturekit/src/sc_stream.rs
+++ b/screencapturekit/src/sc_stream.rs
@@ -33,11 +33,11 @@ impl SCStream {
             },
         );
     }
-    pub fn start_capture(&self) {
-        self._unsafe_ref.start_capture();
+    pub fn start_capture(&self) -> Result<(), String> {
+        self._unsafe_ref.start_capture()
     }
-    pub fn stop_capture(&self) {
-        self._unsafe_ref.stop_capture();
+    pub fn stop_capture(&self) -> Result<(), String> {
+        self._unsafe_ref.stop_capture()
     }
 }
 


### PR DESCRIPTION
https://github.com/svtlabs/screencapturekit-rs/blob/main/screencapturekit-sys/src/stream.rs#L40

I got a error like this:

```
ERROR!
"Failed to stop a stream that is already stopped or does not exist"
thread '<unnamed>' panicked at /Users/tokuhirom/.cargo/git/checkouts/screencapturekit-rs-fba2bd357ef070a5/78cc3db/screencapturekit-sys/./src/stream.rs:40:17:
start fail
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
libc++abi: terminating due to uncaught foreign exception
```

there's no way to handle this error. because it's a `panic!`.
In my opinion, a library shouldn't use `panic!`.
