### PR TITLE
Fix error handling

### DIFF
--- a/screencapturekit/src/sc_error_handler.rs
+++ b/screencapturekit/src/sc_error_handler.rs
@@ -1,6 +1,11 @@
 use screencapturekit_sys::stream_error_handler::UnsafeSCStreamError;
 
-pub trait StreamErrorHandler {
+// TODO: It might make sense to be a little more precise with lifetimes, than 'static.
+// The lifetime could be potentially only as long as the relevant Stream, if the
+// handler was dropped correctly together with the stream. For now the handler is never
+// dropped and lives forever inside a statically allocated HashMap. See the relevant 
+// code in screencapturekit-sys crate.
+pub trait StreamErrorHandler: Send + Sync + 'static {
     fn on_error(&self);
 }
 


### PR DESCRIPTION
In current code the vtable of StreamErrorHandler gets stored and accessed correctly - that's why simple structs with trait implementations that don't read `self` work well. However, somewhere inside the entrails of `screencapturekit-sys` the original struct gets dropped (but surprisingly not its vtable! you can verify this by adding custom Drop impl and seeing it triggered, while the vtable still routes `on_error` calls correctly). This leads to segfaults (because due to vtable being stored correctly, the code tries to access already freed data, which leads to bad data access and sometimes segfaults).

I tried taking ownership of the Handler somewhere inside the safe part of the library, but that involved a lot of lifetime annotations. It's still something we might want to do, because currently once the Handler gets added - it will never be freed and it will live inside the global HashMap forever. And sadly even when I got it to work, the original struct did not get dropped, but the address to `self` inside the `on_error` callback was still wrong - most likely some pointer arithmetic issue (maybe due to the fact that `dyn Trait` is actually a double pointer?).

I added a simple test to showcase the source of the issue. Without my change the `error_rx.recv()` would return an Error claiming that error_tx has already been dropped. What's worse is that `self.error_tx.send(())` would result in segfaults.

My next step might be actually passing the error given by SCK back to the handler (which currently takes no arguments).

Thanks for having a look.