### PR TITLE
Fix ShareableContent when permissions are missing

### DIFF
--- a/screencapturekit-sys/src/shareable_content.rs
+++ b/screencapturekit-sys/src/shareable_content.rs
@@ -125,7 +125,8 @@ unsafe impl Message for UnsafeSCShareableContent {}
 
 type CompletionHandlerBlock = RcBlock<(*mut UnsafeSCShareableContent, *mut Object), ()>;
 impl UnsafeSCShareableContent {
-    unsafe fn new_completion_handler() -> (CompletionHandlerBlock, Receiver<Result<Id<Self>, String>>) {
+    unsafe fn new_completion_handler(
+    ) -> (CompletionHandlerBlock, Receiver<Result<Id<Self>, String>>) {
         let (tx, rx) = channel();
         let handler = ConcreteBlock::new(move |sc: *mut Self, error: *mut Object| {
             if error.is_null() {

--- a/screencapturekit-sys/src/shareable_content.rs
+++ b/screencapturekit-sys/src/shareable_content.rs
@@ -125,21 +125,21 @@ unsafe impl Message for UnsafeSCShareableContent {}
 
 type CompletionHandlerBlock = RcBlock<(*mut UnsafeSCShareableContent, *mut Object), ()>;
 impl UnsafeSCShareableContent {
-    unsafe fn new_completion_handler() -> (CompletionHandlerBlock, Receiver<Id<Self>>) {
+    unsafe fn new_completion_handler() -> (CompletionHandlerBlock, Receiver<Result<Id<Self>, String>>) {
         let (tx, rx) = channel();
         let handler = ConcreteBlock::new(move |sc: *mut Self, error: *mut Object| {
             if error.is_null() {
-                tx.send(Id::from_ptr(sc))
+                tx.send(Ok(Id::from_ptr(sc)))
                     .expect("could create owned pointer for UnsafeSCShareableContent");
             } else {
                 let code: *mut NSString = msg_send![error, localizedDescription];
-                eprintln!("ERR: {:?}", (*code).as_str());
+                tx.send(Err((*code).as_str().to_string()));
             }
         });
         (handler.copy(), rx)
     }
 
-    pub fn get_with_config(config: &ExcludingDesktopWindowsConfig) -> Result<Id<Self>, RecvError> {
+    pub fn get_with_config(config: &ExcludingDesktopWindowsConfig) -> Result<Id<Self>, String> {
         unsafe {
             let (handler, rx) = Self::new_completion_handler();
             match config.on_screen_windows_only {
@@ -169,10 +169,10 @@ impl UnsafeSCShareableContent {
                     completionHandler: handler
                 ],
             }
-            rx.recv()
+            rx.recv().unwrap_or(Err("Failed to recv".to_string()))
         }
     }
-    pub fn get() -> Result<Id<Self>, RecvError> {
+    pub fn get() -> Result<Id<Self>, String> {
         unsafe {
             let (handler, rx) = Self::new_completion_handler();
             let _: () = msg_send![
@@ -180,7 +180,7 @@ impl UnsafeSCShareableContent {
                 getShareableContentWithCompletionHandler: handler
             ];
 
-            rx.recv()
+            rx.recv().unwrap_or(Err("Failed to recv".to_string()))
         }
     }
 

--- a/screencapturekit/src/sc_shareable_content.rs
+++ b/screencapturekit/src/sc_shareable_content.rs
@@ -14,7 +14,11 @@ pub struct SCShareableContent {
 
 impl SCShareableContent {
     pub fn current() -> Self {
-        let unsafe_ref = UnsafeSCShareableContent::get().unwrap();
+        SCShareableContent::try_current().unwrap()
+    }
+
+    pub fn try_current() -> Result<Self, String> {
+        let unsafe_ref = UnsafeSCShareableContent::get()?;
 
         let windows: Vec<SCWindow> = unsafe_ref
             .windows()
@@ -34,12 +38,12 @@ impl SCShareableContent {
             .map(SCDisplay::from)
             .collect();
 
-        SCShareableContent {
+        Ok(SCShareableContent {
             windows,
             applications,
             displays,
             _unsafe_ref: unsafe_ref,
-        }
+        })
     }
 }
 


### PR DESCRIPTION
If the user has blocked ScreenCapture for the current app, getting the current ShareableContent will fail. This makes it possible to catch such scenarios from within rust code.