### PR TITLE
feat: add support for shows_cursor

### DIFF
--- a/screencapturekit-sys/src/stream_configuration.rs
+++ b/screencapturekit-sys/src/stream_configuration.rs
@@ -25,6 +25,7 @@ impl From<UnsafeStreamConfiguration> for Id<UnsafeStreamConfigurationRef> {
             let _: () = msg_send![sys_ref, setPixelFormat: value.pixel_format];
             let _: () = msg_send![sys_ref, setMinimumFrameInterval: value.minimum_frame_interval];
             let _: () = msg_send![sys_ref, setScalesToFit: value.scales_to_fit];
+            let _: () = msg_send![sys_ref, setShowsCursor: value.shows_cursor];
             // let _: () =
             // msg_send![sys_ref, setSetPreservesAspectRatio: value.preserves_aspect_ratio];
         }


### PR DESCRIPTION
Screen capture kit has a `showsCursor` setting configuration which allows the user to decide whether to show the cursor or not in the frames capture. ( https://developer.apple.com/documentation/screencapturekit/scstreamconfiguration/3919828-showscursor )

This PR adds support for this option.