### PR TITLE
feat: Set sample_rate and channel_count via objc interface

### DIFF
--- a/screencapturekit-sys/src/stream_configuration.rs
+++ b/screencapturekit-sys/src/stream_configuration.rs
@@ -26,6 +26,8 @@ impl From<UnsafeStreamConfiguration> for Id<UnsafeStreamConfigurationRef> {
             let _: () = msg_send![sys_ref, setMinimumFrameInterval: value.minimum_frame_interval];
             let _: () = msg_send![sys_ref, setScalesToFit: value.scales_to_fit];
             let _: () = msg_send![sys_ref, setShowsCursor: value.shows_cursor];
+            let _: () = msg_send![sys_ref, setChannelCount: value.channel_count];
+            let _: () = msg_send![sys_ref, setSampleRate: value.sample_rate];
             // let _: () =
             // msg_send![sys_ref, setSetPreservesAspectRatio: value.preserves_aspect_ratio];
         }


### PR DESCRIPTION
**Problem**: I'm not able to set `channel_count` and `sample_rate` in StreamConfiguration as a consumer of this library.

**Solution**: Wire up the setter calls to the actual operations to set the aforementioned attributes via objc interface.

**Testing**: Tested on my Macbook. I'm able to update the aforementioned attributes and see the changes reflected in the channel count and sample rate of the audio samples that I'm receiving in `did_output_sample_buffer` callback.

**Reviewer guidance**: I am only adding the missing attributes that I need. I'm aware that there are still remaining attributes that are not set via objc interface but decided to only focus on `sample_rate` and `channel_count` attributes in this PR since I have high confidence that they would work from my local testing.