### PR TITLE
feat: Extend CVPixelBufferRef and export the new functions from CVPixelBuffer

### DIFF
--- a/screencapturekit-sys/src/cv_pixel_buffer_ref.rs
+++ b/screencapturekit-sys/src/cv_pixel_buffer_ref.rs
@@ -24,6 +24,15 @@ impl CVPixelBufferRef {
     pub fn unlock_base_address(&self, lock_flags: CVPixelBufferLockFlags) -> CVReturn {
         unsafe { CVPixelBufferUnlockBaseAddress(self, lock_flags) }
     }
+    pub fn get_width(&self) -> SizeT {
+        unsafe { CVPixelBufferGetWidth(self) }
+    }
+    pub fn get_height(&self) -> SizeT {
+        unsafe { CVPixelBufferGetHeight(self) }
+    }
+    pub fn get_bytes_per_row_of_plane(&self, plane_index: SizeT) -> SizeT {
+        unsafe { CVPixelBufferGetBytesPerRowOfPlane(self, plane_index) }
+    }
 }
 
 extern "C" {
@@ -44,4 +53,10 @@ extern "C" {
         pixel_buf: *const CVPixelBufferRef,
         lock_flags: CVPixelBufferLockFlags,
     ) -> CVReturn;
+    fn CVPixelBufferGetWidth(pixel_buf: *const CVPixelBufferRef) -> SizeT;
+    fn CVPixelBufferGetHeight(pixel_buf: *const CVPixelBufferRef) -> SizeT;
+    fn CVPixelBufferGetBytesPerRowOfPlane(
+        pixel_buf: *const CVPixelBufferRef,
+        plane_index: SizeT,
+    ) -> SizeT;
 }

--- a/screencapturekit/src/cv_pixel_buffer.rs
+++ b/screencapturekit/src/cv_pixel_buffer.rs
@@ -25,10 +25,19 @@ impl CVPixelBuffer {
     pub fn unlock(&self) -> bool {
         self.unsafe_ref.unlock_base_address(0) == 0
     }
-    pub fn get_base_adress(&self) -> *mut c_void {
+    pub fn get_base_address(&self) -> *mut c_void {
         self.unsafe_ref.get_base_address()
     }
-    pub fn get_base_adress_of_plane(&self, plane_index: u64) -> *mut c_void {
+    pub fn get_base_address_of_plane(&self, plane_index: u64) -> *mut c_void {
         self.unsafe_ref.get_base_address_of_plane(plane_index)
+    }
+    pub fn get_bytes_per_row_of_plane(&self, plane_index: u64) -> u64 {
+        self.unsafe_ref.get_bytes_per_row_of_plane(plane_index)
+    }
+    pub fn get_width(&self) -> u64 {
+        self.unsafe_ref.get_width()
+    }
+    pub fn get_height(&self) -> u64 {
+        self.unsafe_ref.get_height()
     }
 }


### PR DESCRIPTION
Adds the following functions to CVPixelBufferRef
* get_width
* get_height
* get_bytes_per_row_of_plane


and exports them from CVPixelBuffer.