### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.1](https://github.com/doom-fish/screencapturekit-rs/compare/v0.3.0...v0.3.1) - 2024-11-29
+
+### Other
+
+- remove old changelog

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ authors = ["Per Johansson <per@doom.fish>"]
 homepage = "https://github.com/svtlabs"
 edition = "2021"
 rust-version = "1.72"
-version = "0.3.0"
+version = "0.3.1"
 license = "MIT OR Apache-2.0"
 
 [lib]


### PR DESCRIPTION
## 🤖 New release
* `screencapturekit`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/doom-fish/screencapturekit-rs/compare/v0.3.0...v0.3.1) - 2024-11-29

### Other

- remove old changelog
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).