### PR TITLE
chore: release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/doom-fish/screencapturekit-rs/compare/v0.3.2...v0.3.3) - 2024-12-25
+
+### Other
+
+- Update contrib.yml
+- *(contributor)* contrib-readme-action has updated readme (#66)
+- *(contributor)* contrib-readme-action has updated readme (#64)
+
 ## [0.3.2](https://github.com/doom-fish/screencapturekit-rs/compare/v0.3.1...v0.3.2) - 2024-12-19
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ authors = ["Per Johansson <per@doom.fish>"]
 homepage = "https://github.com/svtlabs"
 edition = "2021"
 rust-version = "1.72"
-version = "0.3.2"
+version = "0.3.3"
 license = "MIT OR Apache-2.0"
 
 [lib]


### PR DESCRIPTION
## 🤖 New release
* `screencapturekit`: 0.3.2 -> 0.3.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.3](https://github.com/doom-fish/screencapturekit-rs/compare/v0.3.2...v0.3.3) - 2024-12-25

### Other

- Update contrib.yml
- *(contributor)* contrib-readme-action has updated readme (#66)
- *(contributor)* contrib-readme-action has updated readme (#64)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).