### PR TITLE
chore: release v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5](https://github.com/doom-fish/screencapturekit-rs/compare/v0.3.4...v0.3.5) - 2025-02-06
+
+### Other
+
+- fix releaze action
+- fix bad cargo.toml
+
 ## [0.3.4](https://github.com/doom-fish/screencapturekit-rs/compare/v0.3.3...v0.3.4) - 2025-01-29
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ authors = ["Per Johansson <per@doom.fish>"]
 homepage = "https://github.com/svtlabs"
 edition = "2021"
 rust-version = "1.72"
-version = "0.3.4"
+version = "0.3.5"
 license = "MIT OR Apache-2.0"
 
 [lib]


### PR DESCRIPTION



## 🤖 New release

* `screencapturekit`: 0.3.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.5](https://github.com/doom-fish/screencapturekit-rs/compare/v0.3.4...v0.3.5) - 2025-02-06

### Other

- fix releaze action
- fix bad cargo.toml
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).