### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/doom-fish/screencapturekit-rs/compare/v0.4.0...v0.5.0) - 2025-11-27
+
+### Added
+
+- *(swift-bridge)* add SCBridgeError enum and documentation
+
+### Other
+
+- *(swift-bridge)* update README to reflect modular structure
+- [**breaking**] add 1.0.0 changelog
+- restore Recall.ai sponsor banner
+
 ## [1.0.0] - 2025-11-27
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "screencapturekit"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/doom-fish/screencapturekit-rs"


### PR DESCRIPTION



## 🤖 New release

* `screencapturekit`: 0.4.0 -> 0.5.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.0](https://github.com/doom-fish/screencapturekit-rs/compare/v0.4.0...v0.5.0) - 2025-11-27

### Added

- *(swift-bridge)* add SCBridgeError enum and documentation

### Other

- *(swift-bridge)* update README to reflect modular structure
- [**breaking**] add 1.0.0 changelog
- restore Recall.ai sponsor banner
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).