### PR TITLE
chore: release v1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.2](https://github.com/doom-fish/screencapturekit-rs/compare/v1.4.1...v1.4.2) - 2025-12-15
+
+### Fixed
+
+- remove whitespace between badges
+
+### Other
+
+- change example sample rate that isn't 48000 to be 24000 (which is actually valid) ([#116](https://github.com/doom-fish/screencapturekit-rs/pull/116))
+- update README badges to match LazyVim style
+
 ## [1.4.1](https://github.com/doom-fish/screencapturekit-rs/compare/v1.4.0...v1.4.1) - 2025-12-11
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "screencapturekit"
-version = "1.4.1"
+version = "1.4.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/doom-fish/screencapturekit-rs"


### PR DESCRIPTION



## 🤖 New release

* `screencapturekit`: 1.4.1 -> 1.4.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.4.2](https://github.com/doom-fish/screencapturekit-rs/compare/v1.4.1...v1.4.2) - 2025-12-15

### Fixed

- remove whitespace between badges

### Other

- change example sample rate that isn't 48000 to be 24000 (which is actually valid) ([#116](https://github.com/doom-fish/screencapturekit-rs/pull/116))
- update README badges to match LazyVim style
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).