### PR TITLE
minor: change example non-default sample rate from 44100 to 24000 (which is actually valid)

### DIFF
--- a/examples/15_memory_leak_check.rs
+++ b/examples/15_memory_leak_check.rs
@@ -342,7 +342,7 @@ fn test_capture_with_filter(filter_type: FilterType, duration: &Duration) {
             .with_height(240)
             .with_pixel_format(PixelFormat::BGRA)
             .with_captures_audio(true)
-            .with_sample_rate(44100)
+            .with_sample_rate(24000)
             .with_channel_count(2),
     };
 


### PR DESCRIPTION
This is very minor, but setting a sample rate of 44100 doesn't actually do anything with screencapturekit: https://developer.apple.com/documentation/screencapturekit/scstreamconfiguration/samplerate

> The framework supports sample rates of 8000, 16000, 24000, and 48000. If you don’t specify a sample rate, or specify an unsupported value, the system uses a default sample rate of 48 kHz.

If you're expecting it to actually use that sample rate, the output audio obviously ends up time stretched. For a while I was wondering if this was a bug in this library or screencapturekit because of the example file in this pr 😅 

This should maybe be checked or warned against in the code somehow (maybe an enum?), but for now at least seeing this example won't confuse anyone into thinking that specific 44.1k (and common!) sample rate is possible to use.