### PR TITLE
feat: The build process of Swift follows the features of Rust.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -25,17 +25,30 @@ fn main() {
         }
     }
 
+    let feature_open_15 = env::var("CARGO_FEATURE_MACOS_15_0").is_ok();
+    let feature_open_26 = env::var("CARGO_FEATURE_MACOS_26_0").is_ok();
+    let mut args = vec![
+        "build",
+        "-c",
+        "release",
+        "--package-path",
+        swift_dir,
+        "--scratch-path",
+        &swift_build_dir,
+    ];
+
+    if feature_open_15 {
+        args.push("--features");
+        args.push("macos_15_0");
+    }
+    if feature_open_26 {
+        args.push("--features");
+        args.push("macos_26_0");
+    }
+
     // Build Swift package with build directory in OUT_DIR
     let output = Command::new("swift")
-        .args([
-            "build",
-            "-c",
-            "release",
-            "--package-path",
-            swift_dir,
-            "--scratch-path",
-            &swift_build_dir,
-        ])
+        .args(args)
         .output()
         .expect("Failed to build Swift bridge");
 

--- a/swift-bridge/Package.swift
+++ b/swift-bridge/Package.swift
@@ -37,10 +37,14 @@ func detectSDKMajorVersion() -> Int {
 let sdkMajorVersion = detectSDKMajorVersion()
 
 var swiftSettings: [SwiftSetting] = []
-if sdkMajorVersion >= 15 {
+let env = ProcessInfo.processInfo.environment
+let enableMacOS15 = env["CARGO_FEATURE_MACOS_15_0"] != nil && sdkMajorVersion >= 15
+let enableMacOS26 = env["CARGO_FEATURE_MACOS_26_0"] != nil && sdkMajorVersion >= 26
+
+if enableMacOS15 {
     swiftSettings.append(.define("SCREENCAPTUREKIT_HAS_MACOS15_SDK"))
 }
-if sdkMajorVersion >= 26 {
+if enableMacOS26 {
     swiftSettings.append(.define("SCREENCAPTUREKIT_HAS_MACOS26_SDK"))
 }
 


### PR DESCRIPTION
I do not have access to older versions of macOS, and I do not want to introduce GitHub Actions. I would prefer the build requirements to be controlled by Rust features rather than by the operating system version.