### PR TITLE
chore: release v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1](https://github.com/doom-fish/screencapturekit-rs/compare/v1.5.0...v1.5.1) - 2026-02-25
+
+### Fixed
+
+- use cargo features instead of macOS SDK version ([#126](https://github.com/doom-fish/screencapturekit-rs/pull/126))
+
+### Other
+
+- *(deps)* update eframe requirement from 0.30 to 0.33 ([#121](https://github.com/doom-fish/screencapturekit-rs/pull/121))
+
 ## [1.5.0](https://github.com/doom-fish/screencapturekit-rs/compare/v1.4.2...v1.5.0) - 2025-12-20
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "screencapturekit"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/doom-fish/screencapturekit-rs"


### PR DESCRIPTION



## 🤖 New release

* `screencapturekit`: 1.5.0 -> 1.5.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.5.1](https://github.com/doom-fish/screencapturekit-rs/compare/v1.5.0...v1.5.1) - 2026-02-25

### Fixed

- use cargo features instead of macOS SDK version ([#126](https://github.com/doom-fish/screencapturekit-rs/pull/126))

### Other

- *(deps)* update eframe requirement from 0.30 to 0.33 ([#121](https://github.com/doom-fish/screencapturekit-rs/pull/121))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).