### PR TITLE
fix: weak-link ScreenCaptureKit to prevent dyld crash on older macOS

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,11 @@ use std::env;
 use std::process::Command;
 
 fn main() {
-    println!("cargo:rustc-link-lib=framework=ScreenCaptureKit");
+    // Weak-link ScreenCaptureKit so that classes only available in newer macOS versions
+    // (e.g., SCScreenshotConfiguration in macOS 26.0+) don't cause dyld crashes at load
+    // time when running on older macOS versions. Swift's `if #available` runtime checks
+    // handle the actual availability gating.
+    println!("cargo:rustc-link-arg=-Wl,-weak_framework,ScreenCaptureKit");
 
     // Build the Swift bridge
     let swift_dir = "swift-bridge";


### PR DESCRIPTION
When building with the macOS 26.0 SDK on macOS 15.x, the Swift bridge compiles references to SCScreenshotConfiguration. Strong linking causes dyld to abort at load time when the symbol is missing:
```
dyld[29625]: Symbol not found: _OBJC_CLASS_$_SCScreenshotConfiguration
  Referenced from: <215C1D65-FC61-3D0C-BC6F-B524150D3B9A> /Users/akx/build/screencapturekit-rs/target/debug/deps/audio_buffer_tests-9b27841747c767db
  Expected in:     <25AEF9F6-1B31-3048-A003-E7F5C1724F14> /System/Library/Frameworks/ScreenCaptureKit.framework/Versions/A/ScreenCaptureKit
```

The upshot is that `cargo test` at least runs on macOS 15.7.3 when `xcrun --show-sdk-version` says 26.0.