### PR TITLE
chore: release v1.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.4](https://github.com/doom-fish/screencapturekit-rs/compare/v1.5.3...v1.5.4) - 2026-03-09
+
+### Fixed
+
+- per-stream callback routing to prevent cross-stream sample leaking ([#135](https://github.com/doom-fish/screencapturekit-rs/pull/135)) ([#136](https://github.com/doom-fish/screencapturekit-rs/pull/136))
+
 ## [1.5.3](https://github.com/doom-fish/screencapturekit-rs/compare/v1.5.2...v1.5.3) - 2026-03-05
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "screencapturekit"
-version = "1.5.3"
+version = "1.5.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/doom-fish/screencapturekit-rs"


### PR DESCRIPTION



## 🤖 New release

* `screencapturekit`: 1.5.3 -> 1.5.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.5.4](https://github.com/doom-fish/screencapturekit-rs/compare/v1.5.3...v1.5.4) - 2026-03-09

### Fixed

- per-stream callback routing to prevent cross-stream sample leaking ([#135](https://github.com/doom-fish/screencapturekit-rs/pull/135)) ([#136](https://github.com/doom-fish/screencapturekit-rs/pull/136))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).