### PR TITLE
chore: release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/doom-fish/screencapturekit-rs/compare/v1.5.4...v2.0.0) - 2026-05-06
+
+### Added
+
+- *(picker)* expose SCContentSharingPicker.isActive getter and setter
+- *(picker)* expose SCContentSharingPicker.defaultConfiguration
+- *(cm)* expose SCStreamFrameInfo.presenterOverlayContentRect attachment
+- *(pixel-format)* [**breaking**] surface unrecognised codes via PixelFormat::Unknown
+- *(error)* [**breaking**] mark SCStreamErrorCode as #[non_exhaustive]
+
+### Fixed
+
+- *(ci)* use release-plz prebuilt action instead of cargo install
+- *(build)* force `--sdk macosx` in xcrun invocation to bypass stale CLT defaults
+- *(pixel-format)* [**breaking**] normalise PartialEq/Hash through FourCharCode
+- *(panic-safety)* wrap user code in remaining extern "C" callbacks
+- *(build)* [**breaking**] propagate every macos_* feature; fail loudly on SDK detection failure
+- *(build)* improve rebuild triggers and xcode-select error visibility
+- *(ffi)* defend FFI string helpers against malformed Swift output
+- *(stream)* [**breaking**] require Send + Sync on output and delegate traits
+- *(completion)* atomic guard against double-invocation; lost-wakeup race in poll
+- *(async)* lost-wakeup race in NextSample/NextRecordingEvent polls; clippy
+- *(swift)* correct C-header drift; document dispatch-queue affinity deviation
+- *(stream)* panic-safety, lock contention, and hot-path allocation in sample dispatch
+
+### Other
+
+- *(deps)* upgrade dev-dependencies to current major versions
+- *(swift-bridge)* re-enable SwiftLint force_unwrapping rule
+- *(examples)* add Tauri entitlements + warn 23_client_server is toy IPC
+- *(examples)* replace permission-sensitive panics with graceful skip messages
+- *(api)* clarify hot-path costs, lifetime conventions, and prelude omissions
+- route permission-skip messages to stderr with SKIP: prefix (M12)
+- cover YUV pixel format and mid-capture handler lifecycle (M11)
+- *(bench)* rewrite frame-throughput bench; add stream-startup bench
+- end-to-end cross-stream isolation regression test for #135
+
 ## [1.5.4](https://github.com/doom-fish/screencapturekit-rs/compare/v1.5.3...v1.5.4) - 2026-03-09
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "screencapturekit"
-version = "1.5.4"
+version = "2.0.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/doom-fish/screencapturekit-rs"


### PR DESCRIPTION



## 🤖 New release

* `screencapturekit`: 1.5.4 -> 2.0.0 (⚠ API breaking changes)

### ⚠ `screencapturekit` breaking changes

```text
--- failure enum_discriminants_undefined_non_unit_variant: enum's variants no longer have defined discriminants due to non-unit variant ---

Description:
An enum's variants no longer have well-defined discriminant values due to a tuple or struct variant in the enum. This breaks downstream code that accesses discriminants via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_discriminants_undefined_non_unit_variant.ron

Failed in:
  enum PixelFormat in /private/var/folders/tb/y368xp_x10s3ty1b_mtl5mxr0000gn/T/.tmpkwUIB7/screencapturekit-rs/src/stream/configuration/pixel_format.rs:49
  enum PixelFormat in /private/var/folders/tb/y368xp_x10s3ty1b_mtl5mxr0000gn/T/.tmpkwUIB7/screencapturekit-rs/src/stream/configuration/pixel_format.rs:49
  enum PixelFormat in /private/var/folders/tb/y368xp_x10s3ty1b_mtl5mxr0000gn/T/.tmpkwUIB7/screencapturekit-rs/src/stream/configuration/pixel_format.rs:49

--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---

Description:
A public enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_marked_non_exhaustive.ron

Failed in:
  enum PixelFormat in /private/var/folders/tb/y368xp_x10s3ty1b_mtl5mxr0000gn/T/.tmpkwUIB7/screencapturekit-rs/src/stream/configuration/pixel_format.rs:49
  enum PixelFormat in /private/var/folders/tb/y368xp_x10s3ty1b_mtl5mxr0000gn/T/.tmpkwUIB7/screencapturekit-rs/src/stream/configuration/pixel_format.rs:49
  enum PixelFormat in /private/var/folders/tb/y368xp_x10s3ty1b_mtl5mxr0000gn/T/.tmpkwUIB7/screencapturekit-rs/src/stream/configuration/pixel_format.rs:49
  enum SCStreamErrorCode in /private/var/folders/tb/y368xp_x10s3ty1b_mtl5mxr0000gn/T/.tmpkwUIB7/screencapturekit-rs/src/utils/error.rs:506
  enum SCStreamErrorCode in /private/var/folders/tb/y368xp_x10s3ty1b_mtl5mxr0000gn/T/.tmpkwUIB7/screencapturekit-rs/src/utils/error.rs:506

--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait screencapturekit::stream::output_trait::SCStreamOutputTrait gained Sync in file /private/var/folders/tb/y368xp_x10s3ty1b_mtl5mxr0000gn/T/.tmpkwUIB7/screencapturekit-rs/src/stream/output_trait.rs:83
  trait screencapturekit::stream::SCStreamOutput gained Sync in file /private/var/folders/tb/y368xp_x10s3ty1b_mtl5mxr0000gn/T/.tmpkwUIB7/screencapturekit-rs/src/stream/output_trait.rs:83
  trait screencapturekit::prelude::SCStreamOutputTrait gained Sync in file /private/var/folders/tb/y368xp_x10s3ty1b_mtl5mxr0000gn/T/.tmpkwUIB7/screencapturekit-rs/src/stream/output_trait.rs:83
  trait screencapturekit::stream::delegate_trait::SCStreamDelegateTrait gained Sync in file /private/var/folders/tb/y368xp_x10s3ty1b_mtl5mxr0000gn/T/.tmpkwUIB7/screencapturekit-rs/src/stream/delegate_trait.rs:66
  trait screencapturekit::stream::SCStreamDelegate gained Sync in file /private/var/folders/tb/y368xp_x10s3ty1b_mtl5mxr0000gn/T/.tmpkwUIB7/screencapturekit-rs/src/stream/delegate_trait.rs:66
  trait screencapturekit::prelude::SCStreamDelegateTrait gained Sync in file /private/var/folders/tb/y368xp_x10s3ty1b_mtl5mxr0000gn/T/.tmpkwUIB7/screencapturekit-rs/src/stream/delegate_trait.rs:66
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.0](https://github.com/doom-fish/screencapturekit-rs/compare/v1.5.4...v2.0.0) - 2026-05-06

### Added

- *(picker)* expose SCContentSharingPicker.isActive getter and setter
- *(picker)* expose SCContentSharingPicker.defaultConfiguration
- *(cm)* expose SCStreamFrameInfo.presenterOverlayContentRect attachment
- *(pixel-format)* [**breaking**] surface unrecognised codes via PixelFormat::Unknown
- *(error)* [**breaking**] mark SCStreamErrorCode as #[non_exhaustive]

### Fixed

- *(ci)* use release-plz prebuilt action instead of cargo install
- *(build)* force `--sdk macosx` in xcrun invocation to bypass stale CLT defaults
- *(pixel-format)* [**breaking**] normalise PartialEq/Hash through FourCharCode
- *(panic-safety)* wrap user code in remaining extern "C" callbacks
- *(build)* [**breaking**] propagate every macos_* feature; fail loudly on SDK detection failure
- *(build)* improve rebuild triggers and xcode-select error visibility
- *(ffi)* defend FFI string helpers against malformed Swift output
- *(stream)* [**breaking**] require Send + Sync on output and delegate traits
- *(completion)* atomic guard against double-invocation; lost-wakeup race in poll
- *(async)* lost-wakeup race in NextSample/NextRecordingEvent polls; clippy
- *(swift)* correct C-header drift; document dispatch-queue affinity deviation
- *(stream)* panic-safety, lock contention, and hot-path allocation in sample dispatch

### Other

- *(deps)* upgrade dev-dependencies to current major versions
- *(swift-bridge)* re-enable SwiftLint force_unwrapping rule
- *(examples)* add Tauri entitlements + warn 23_client_server is toy IPC
- *(examples)* replace permission-sensitive panics with graceful skip messages
- *(api)* clarify hot-path costs, lifetime conventions, and prelude omissions
- route permission-skip messages to stderr with SKIP: prefix (M12)
- cover YUV pixel format and mid-capture handler lifecycle (M11)
- *(bench)* rewrite frame-throughput bench; add stream-startup bench
- end-to-end cross-stream isolation regression test for #135
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).