### PR TITLE
chore: release v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1](https://github.com/doom-fish/screencapturekit-rs/compare/v2.1.0...v2.1.1) - 2026-05-13
+
+### Other
+
+- *(readme)* restructure for faster onboarding
+- update README and MIGRATION for 2.x
+- expand 'Used By' section with verified projects
+
 ## [2.1.0](https://github.com/doom-fish/screencapturekit-rs/compare/v2.0.0...v2.1.0) - 2026-05-11
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "screencapturekit"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/doom-fish/screencapturekit-rs"


### PR DESCRIPTION



## 🤖 New release

* `screencapturekit`: 2.1.0 -> 2.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.1.1](https://github.com/doom-fish/screencapturekit-rs/compare/v2.1.0...v2.1.1) - 2026-05-13

### Other

- *(readme)* restructure for faster onboarding
- update README and MIGRATION for 2.x
- expand 'Used By' section with verified projects
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).