### PR TITLE
chore: release v7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.0.0](https://github.com/doom-fish/screencapturekit-rs/compare/v6.1.0...v7.0.0) - 2026-05-29
+
+### Added
+
+- add strided pixel render + locked IOSurface CPU view; use ffi_string helper for file_url
+
+### Fixed
+
+- use MaybeUninit for batch FFI scratch buffers
+
+### Other
+
+- cap dev-only bitflags below 2.12 to fix dispatch2 recursion overflow
+- Merge ffi/wrappers: sc_retained! macro + null-checked constructors
+- consolidate retain/release wrappers via sc_retained! macro and standardize null-checked constructors
+- Merge ffi/picker: reclaim observer callback on replacement + consolidate one-shot trampolines
+- Merge ffi/screenshot: strided pixel render + ffi_string helper for file_url
+
 ## [6.1.0](https://github.com/doom-fish/screencapturekit-rs/compare/v6.0.1...v6.1.0) - 2026-05-29
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "screencapturekit"
-version = "6.1.0"
+version = "7.0.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/doom-fish/screencapturekit-rs"


### PR DESCRIPTION



## 🤖 New release

* `screencapturekit`: 6.1.0 -> 7.0.0 (⚠ API breaking changes)

### ⚠ `screencapturekit` breaking changes

```text
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/function_parameter_count_changed.ron

Failed in:
  screencapturekit::ffi::sc_stream_create now takes 7 parameters instead of 5, in /private/var/folders/8j/sfr9qqcj73j4p6nhwcfpr0th0000gn/T/.tmpzOPoCK/screencapturekit-rs/src/ffi/mod.rs:548

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/trait_method_added.ron

Failed in:
  trait method screencapturekit::screenshot_manager::CGImageExt::rgba_data_into_strided in file /private/var/folders/8j/sfr9qqcj73j4p6nhwcfpr0th0000gn/T/.tmpzOPoCK/screencapturekit-rs/src/screenshot_manager.rs:268
  trait method screencapturekit::screenshot_manager::CGImageExt::bgra_data_into_strided in file /private/var/folders/8j/sfr9qqcj73j4p6nhwcfpr0th0000gn/T/.tmpzOPoCK/screencapturekit-rs/src/screenshot_manager.rs:284
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [7.0.0](https://github.com/doom-fish/screencapturekit-rs/compare/v6.1.0...v7.0.0) - 2026-05-29

### Added

- add strided pixel render + locked IOSurface CPU view; use ffi_string helper for file_url

### Fixed

- use MaybeUninit for batch FFI scratch buffers

### Other

- cap dev-only bitflags below 2.12 to fix dispatch2 recursion overflow
- Merge ffi/wrappers: sc_retained! macro + null-checked constructors
- consolidate retain/release wrappers via sc_retained! macro and standardize null-checked constructors
- Merge ffi/picker: reclaim observer callback on replacement + consolidate one-shot trampolines
- Merge ffi/screenshot: strided pixel render + ffi_string helper for file_url
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).