### PR TITLE
chore: release v7.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.0.1](https://github.com/doom-fish/screencapturekit-rs/compare/v7.0.0...v7.0.1) - 2026-06-06
+
+### Fixed
+
+- resolve safety/FFI findings from deep code review
+
+### Other
+
+- apply rustfmt to satisfy CI formatting check
+- *(deps)* update bitflags requirement from >=2.0, <2.12 to >=2.0, <2.13 ([#150](https://github.com/doom-fish/screencapturekit-rs/pull/150))
+
 ## [7.0.0](https://github.com/doom-fish/screencapturekit-rs/compare/v6.1.0...v7.0.0) - 2026-05-29
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "screencapturekit"
-version = "7.0.0"
+version = "7.0.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/doom-fish/screencapturekit-rs"


### PR DESCRIPTION



## 🤖 New release

* `screencapturekit`: 7.0.0 -> 7.0.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [7.0.1](https://github.com/doom-fish/screencapturekit-rs/compare/v7.0.0...v7.0.1) - 2026-06-06

### Fixed

- resolve safety/FFI findings from deep code review

### Other

- apply rustfmt to satisfy CI formatting check
- *(deps)* update bitflags requirement from >=2.0, <2.12 to >=2.0, <2.13 ([#150](https://github.com/doom-fish/screencapturekit-rs/pull/150))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).