### PR TITLE
chore: release v8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.0](https://github.com/doom-fish/screencapturekit-rs/compare/v7.0.1...v8.0.0) - 2026-06-19
+
+### Added
+
+- *(async)* implement futures::Stream for AsyncSCStream and recording events
+- *(async)* multi-output AsyncSCStream (capture A/V from one stream)
+- *(async)* [**breaking**] propagate stop errors in AsyncSCStream; consolidate stop delegate
+- *(async)* [**breaking**] make AsyncSCStream lifecycle methods truly async
+
+### Fixed
+
+- *(stream)* surface failed output-handler registration instead of dropping it silently
+
+### Other
+
+- *(deps-dev)* raise bitflags cap to <2.14 (fixes fresh-resolve to 2.13.0)
+- *(readme)* update for v8 async API
+- *(examples)* add audio+video multi-output showcase; apply rustfmt
+- restore Recall.ai sponsor banner and update v6 references to v7
+
 ### Changed
 
 - [**breaking**] `AsyncSCStream::start_capture`, `stop_capture`, `update_configuration`,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "screencapturekit"
-version = "7.0.1"
+version = "8.0.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/doom-fish/screencapturekit-rs"


### PR DESCRIPTION



## 🤖 New release

* `screencapturekit`: 7.0.1 -> 8.0.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [8.0.0](https://github.com/doom-fish/screencapturekit-rs/compare/v7.0.1...v8.0.0) - 2026-06-19

### Added

- *(async)* implement futures::Stream for AsyncSCStream and recording events
- *(async)* multi-output AsyncSCStream (capture A/V from one stream)
- *(async)* [**breaking**] propagate stop errors in AsyncSCStream; consolidate stop delegate
- *(async)* [**breaking**] make AsyncSCStream lifecycle methods truly async

### Fixed

- *(stream)* surface failed output-handler registration instead of dropping it silently

### Other

- *(deps-dev)* raise bitflags cap to <2.14 (fixes fresh-resolve to 2.13.0)
- *(readme)* update for v8 async API
- *(examples)* add audio+video multi-output showcase; apply rustfmt
- restore Recall.ai sponsor banner and update v6 references to v7

### Changed

- [**breaking**] `AsyncSCStream::start_capture`, `stop_capture`, `update_configuration`,
  and `update_content_filter` are now genuinely async: they return a
  `StreamControlFuture` (resolving to `Result<(), SCError>`) that you `.await`,
  instead of blocking the calling thread on a condition variable. Awaiting them
  parks the task via its `Waker` and resumes from the Swift completion callback,
  so they no longer stall single-threaded/current-thread executors. This makes
  the async surface fully waker-based and consistent with the underlying Swift
  `Task { try await … }` entry points.

  Migration: add `.await` (e.g. `stream.start_capture().await?`). For a
  blocking call, use the synchronous `SCStream` directly via
  `stream.inner().start_capture()`.

- `AsyncSCStream` now installs a stream delegate so that when `ScreenCaptureKit`
  stops the stream with an error (display disconnected, permission revoked, …)
  the sample iterator is closed — `next().await` resolves to `None` instead of
  pending forever — and the error is recorded (see `take_error`). `AsyncSCStream::new`
  likewise no longer silently swallows a failed output-handler registration: it
  closes the stream and records the error.

- The stream engine now dispatches a single canonical stop callback,
  `SCStreamDelegateTrait::did_stop_with_error`, on an error stop. It no longer
  also calls `stream_did_stop` for the same event (the previous behavior fired
  both). `StreamCallbacks::on_stop` keeps working (it is now driven by
  `did_stop_with_error`).

### Added

- `async_api::StreamControlFuture` — the `Send` future returned by the
  `AsyncSCStream` lifecycle methods.
- `AsyncSCStream::take_error` — returns the `SCError` that stopped the stream,
  if any, after `next()` reports the iterator closed.
- Multi-output async capture: `AsyncSCStream::add_output_type` registers an
  additional output type (e.g. add audio to a screen stream), and
  `AsyncSCStream::next_typed` / `try_next_typed` (plus the `NextSampleTyped`
  future) yield each sample together with its `SCStreamOutputType` so audio and
  video can be captured from one stream and told apart.
- `futures::Stream` integration (enabled by the `async` feature, via a new
  optional `futures-core` dependency): `AsyncSCStream::frames` /
  `frames_typed` and `AsyncSCRecordingOutput::events` return
  `futures_core::Stream`s (`SampleStream`, `TypedSampleStream`,
  `RecordingEventStream`) so captures plug into the `StreamExt` combinator
  ecosystem (`map`, `filter`, `take`, `for_each`, `collect`, …).

### Deprecated

- `SCStreamDelegateTrait::stream_did_stop` — `ScreenCaptureKit` only reports
  stops via `did_stop_with_error`, which is now the single source of truth;
  the engine no longer invokes `stream_did_stop`. Implement `did_stop_with_error`
  instead.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).