### PR TITLE
chore: release v8.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.1](https://github.com/doom-fish/screencapturekit-rs/compare/v8.0.0...v8.0.1) - 2026-07-18
+
+### Other
+
+- Avoid duplicate Swift symbols from apple-cf ([#159](https://github.com/doom-fish/screencapturekit-rs/pull/159))
+- *(deps)* update bevy requirement from 0.18 to 0.19 ([#154](https://github.com/doom-fish/screencapturekit-rs/pull/154))
+
 ## [8.0.0](https://github.com/doom-fish/screencapturekit-rs/compare/v7.0.1...v8.0.0) - 2026-06-19
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "screencapturekit"
-version = "8.0.0"
+version = "8.0.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/doom-fish/screencapturekit-rs"


### PR DESCRIPTION



## 🤖 New release

* `screencapturekit`: 8.0.0 -> 8.0.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [8.0.1](https://github.com/doom-fish/screencapturekit-rs/compare/v8.0.0...v8.0.1) - 2026-07-18

### Other

- Avoid duplicate Swift symbols from apple-cf ([#159](https://github.com/doom-fish/screencapturekit-rs/pull/159))
- *(deps)* update bevy requirement from 0.18 to 0.19 ([#154](https://github.com/doom-fish/screencapturekit-rs/pull/154))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).