### PR TITLE
Avoid duplicate Swift symbols from apple-cf

### DIFF
--- a/examples/16_full_metal_app/ui.rs
+++ b/examples/16_full_metal_app/ui.rs
@@ -99,7 +99,7 @@ impl VertexBufferBuilder {
             ("Select a Source to Begin".to_string(), [0.6, 0.5, 0.7, 1.0])
         } else if has_source {
             let display = if source_name.len() > 30 {
-                format!("{}...", &source_name.chars().take(27).collect::<String>())
+                format!("{}...", source_name.chars().take(27).collect::<String>())
             } else {
                 source_name.to_string()
             };
@@ -176,7 +176,7 @@ impl VertexBufferBuilder {
         if !format_info.is_empty() {
             // Truncate if too long
             let display_info = if format_info.len() > 40 {
-                format!("{}...", &format_info.chars().take(37).collect::<String>())
+                format!("{}...", format_info.chars().take(37).collect::<String>())
             } else {
                 format_info.to_string()
             };
@@ -293,7 +293,7 @@ impl VertexBufferBuilder {
             self.text(font, name, text_x, text_y, scale, name_color);
 
             let t: String = if value.len() > 12 {
-                format!("{}...", &value.chars().take(9).collect::<String>())
+                format!("{}...", value.chars().take(9).collect::<String>())
             } else {
                 value
             };

--- a/swift-bridge/Package.swift
+++ b/swift-bridge/Package.swift
@@ -6,9 +6,9 @@ import PackageDescription
 //
 // Note: CoreGraphicsBridge / CoreVideoBridge / IOSurfaceBridge / DispatchBridge
 // targets that used to live here were extracted into apple-cf-rs's bridge.
-// CoreMediaBridge here keeps only the SCStreamFrameInfo attachment readers
-// and a few generic accessors with frame-info-specific signatures —
-// everything else comes from apple-cf's CoreMediaBridge target.
+// ScreenCaptureKitCoreMediaBridge keeps only the SCStreamFrameInfo attachment
+// readers and a few generic accessors with frame-info-specific signatures.
+// Generic CoreMedia bindings come from apple-cf's CoreMediaBridge target.
 
 let package = Package(
     name: "ScreenCaptureKitBridge",
@@ -25,14 +25,14 @@ let package = Package(
         // Main ScreenCaptureKit bindings.
         .target(
             name: "ScreenCaptureKitBridge",
-            dependencies: ["CoreMediaBridge", "MetalBridge"],
+            dependencies: ["ScreenCaptureKitCoreMediaBridge", "MetalBridge"],
             path: "Sources/ScreenCaptureKitBridge"),
         // CoreMedia bindings — only the SCStreamFrameInfo attachment readers
         // and SC-specific sample-buffer helpers. Generic CMSampleBuffer /
         // CMBlockBuffer / CMFormatDescription accessors come from
         // apple-cf-rs's CoreMediaBridge.
         .target(
-            name: "CoreMediaBridge",
+            name: "ScreenCaptureKitCoreMediaBridge",
             path: "Sources/CoreMedia"),
         // Metal framework bindings (MTLDevice, MTLTexture, etc.) — apple-cf
         // doesn't provide a metal module yet so this stays local.


### PR DESCRIPTION
I encountered duplicate-symbol linker warnings while using `screencapturekit` with `apple-cf` after update on latest Rust 1.97.

Both crates build a Swift target named `CoreMediaBridge` and define `AudioBufferBridge` and `AudioBufferListRaw`. When a downstream binary pulls in both object files, their Swift metadata symbols collide. Rust 1.97 now exposes this linker output by default.

This PR renames screencapturekit's private target to`ScreenCaptureKitCoreMediaBridge`, giving it a distinct Swift module namespace. The source path and all `@_cdecl` exports remain unchanged, so there is no Rust or C API change.

The second commit removes three redundant borrows reported by Rust 1.97 Clippy so the existing all-target CI check remains clean.

Used gpt5.6 sol model for it, but I keep only small changes to fix old bug and lint for latest Rust.